### PR TITLE
use xdotool --type to replce `ctrl+v`, linux only

### DIFF
--- a/minecraft-chat-helper.sh
+++ b/minecraft-chat-helper.sh
@@ -24,16 +24,13 @@
 
 set -e
 which zenity &>/dev/null || (echo '错误：zenity 程序未安装。' >&2; exit 2)
-which xclip &>/dev/null || (echo '错误：xclip 程序未安装。' >&2; zenity --error --text '错误：xclip 程序未安装' --title 'Minecraft 中文聊天辅助工具'; exit 2)
 which xdotool &>/dev/null || (echo '错误：xdotool 程序未安装。' >&2; zenity --error --text '错误：xdotool 程序未安装' --title 'Minecraft 中文聊天辅助工具'; exit 2)
-_mcchat_input="$(zenity --entry --text '保持 Minecraft 处于暂停界面并在此输入聊天内容：' --title 'Minecraft 中文聊天辅助工具' --entry-text "$(xclip -o -selection clipboard)")"
+_mcchat_input="$(zenity --entry --text '保持 Minecraft 处于暂停界面并在此输入聊天内容：' --title 'Minecraft 中文聊天辅助工具')"
 test -z "$_mcchat_input" && exit 0
-echo -n "$_mcchat_input" | xclip -selection clipboard
 #wmctrl -a 'Minecraft'
 xdotool key --clearmodifiers Escape
 sleep 0.25
 xdotool key t
 sleep 0.25
-xdotool key Control_L+v
-sleep 0.25
+xdotool type --delay 150 "$_mcchat_input"
 xdotool key Return


### PR DESCRIPTION
- #5  
- ref: http://lilydjwg.is-programmer.com/2015/5/17/input-chinese-to-minecraft-in-linux.93167.html
- remove xclip 
